### PR TITLE
Fix: Show 'Saved!' snackbar only on manual save, not on auto-save

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const portfolioInput = document.getElementById('portfolio');
     const customLinksContainer = document.getElementById('custom-links');
     const autoSaveButton = document.getElementById('autoSave');
+    let manualSave = false; // Flag to track if the save is manual
 
     // Load saved links from Chrome storage
     chrome.storage.sync.get(['github', 'linkedin', 'portfolio', 'customLinks'], (result) => {
@@ -45,7 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Function to save all links
-    function saveAllLinks() {
+    function saveAllLinks(isManual = false) {
         const github = githubInput.value;
         const linkedin = linkedinInput.value;
         const portfolio = portfolioInput.value;
@@ -58,12 +59,17 @@ document.addEventListener('DOMContentLoaded', () => {
             };
         });
 
-        chrome.storage.sync.set({ github, linkedin, portfolio, customLinks }).then(() => showSnackbar('Saved!'));
+        chrome.storage.sync.set({ github, linkedin, portfolio, customLinks }).then(() => {
+            if (isManual) {
+                showSnackbar('Saved!');
+            }
+        });
     }
 
     // Modify existing save button click event
     document.getElementById('save').addEventListener('click', () => {
-        saveAllLinks()
+        manualSave = true; // Mark as manual save
+        saveAllLinks(true); // Pass `true` to trigger the snackbar
     });
 
     // Add input event listeners for auto-save
@@ -138,6 +144,7 @@ document.addEventListener('DOMContentLoaded', () => {
         deleteButton.className = 'button-35 delete-button'; // Add class for styling if needed
         deleteButton.addEventListener('click', () => {
             newLinkContainer.remove(); // Remove the custom link container
+            if (autoSaveButton.classList.contains('auto-save-enabled')) saveAllLinks();
         });
         newLinkContainer.appendChild(deleteButton);
 


### PR DESCRIPTION
### Description:
This pull request addresses an issue where the "Saved!" snackbar would appear every time changes were made to the input fields, even if the user hadn't explicitly clicked the "Save" button. The snackbar should only display when the user performs a manual save action.

### Changes Made:
1. **Manual vs Auto Save Handling**:
   - Added a `manualSave` flag to distinguish between manual saves (via the "Save" button) and auto-saves (triggered by input changes).
   - Updated the `saveAllLinks` function to accept a parameter (`isManual`) that determines whether to show the "Saved!" snackbar or not.
   
2. **Prevent Snackbar on Auto-Save**:
   - Adjusted the logic inside the `saveAllLinks` function to prevent the "Saved!" snackbar from appearing when the auto-save feature is enabled.

3. **Save Button Event Listener**:
   - The "Save" button event now triggers the snackbar message correctly after saving.

4. **Custom Link Deletion**:
   - Ensured that when a custom link is deleted, the auto-save mechanism saves the state without triggering the snackbar.
